### PR TITLE
Add helper for nested getjso lookups

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,13 +112,13 @@
   second value indicating whether the value was found (like
   <code>gethash</code>). Can be used with <code>setf</code>.</p>
 
-  <p class="def" id="get-nested-jso">
-    <span>function</span> get-nested-jso (keys jso)
+  <p class="def" id="getjso*">
+    <span>function</span> getjso* (keys jso)
     <br/>&#8594; value
   </p>
 
-  <p class="desc">Takes a key of the form "a.b.c.etc" and generates
-  a series of getjso calls that descend into the object as expected.
+  <p class="desc">Takes a key of the form "a.b.c", generates a series
+  of getjso calls that descend into the object and returns 'c'.
 
   <p class="def" id="mapjso">
     <span>function</span> mapjso (function jso)

--- a/st-json.asd
+++ b/st-json.asd
@@ -1,4 +1,4 @@
 (asdf:defsystem :st-json
   :description "JSON in- and output"
-  :depends-on (#:split-sequence)
+  :depends-on ()
   :components ((:file "st-json")))

--- a/st-json.lisp
+++ b/st-json.lisp
@@ -1,11 +1,10 @@
 (defpackage :st-json
   (:use :common-lisp)
-  (:import-from :split-sequence #:split-sequence)
   (:export #:read-json #:read-json-as-type #:read-json-from-string
            #:write-json #:write-json-to-string #:write-json-element
            #:as-json-bool #:from-json-bool
            #:json-bool #:json-null
-           #:jso #:getjso #:mapjso
+           #:jso #:getjso #:getjso* #:mapjso
            #:json-error #:json-type-error #:json-parse-error
            #:json-eof-error
            #:*script-tag-hack*))
@@ -55,14 +54,12 @@ gethash."
   (loop :for (key . val) :in (jso-alist map)
         :do (funcall func key val)))
 
-(defmacro get-nested-jso (keys jso)
-  (let ((keys (etypecase keys
-                (list keys)
-                (string (split-sequence #\. keys)))))
-    (if (< (length keys) 2)
-        `(st-json:getjso ,(first keys) ,jso)
-        `(st-json:getjso ,(first (last keys))
-                         (get-nested-jso ,(butlast keys) ,jso)))))
+(defmacro getjso* (keys jso)
+  (let ((last (position #\. keys :from-end t)))
+    (if last
+        `(getjso ,(subseq keys (1+ last))
+                 (getjso* ,(subseq keys 0 last) ,jso))
+        `(getjso ,keys ,jso))))
 
 ;; Reader
 


### PR DESCRIPTION
Marijn,

```
(macroexpand-all '(get-nested-jso "a.b.c" jso)) -> (getjso "c" (getjso "b" (getjso "a" jso)))
```

Doing nested getjso lookups feels and looks a bit clumsy to me and it was simple to whip up a macro that rectifies the issue. Granted, it adds a dependency on split-sequence but in these quicklisp days I don't see that as a problem. Any improvements/thoughts on this?

Thanks for your time and keep up all the great work on Rust!

Cheers,
Brit Butler
