### PR TITLE
UTF-16 surrogate pairs

### DIFF
--- a/st-json.lisp
+++ b/st-json.lisp
@@ -315,41 +315,26 @@ Raises a json-type-error when the type is wrong."
   (declare #.*optimize* (stream stream))
   (let ((element (coerce element 'simple-string)))
     (write-char #\" stream)
-    (if *script-tag-hack*
-        (loop :for prev := nil :then ch
-           :for ch :of-type character :across element :do
-           (let ((code (char-code ch)))
-             (declare (fixnum code))
-             (if (or (<= 0 code #x1f)
-                     (<= #x7f code #x9f))
-                 (case code
-                   (#.(char-code #\backspace) (write-string "\\b" stream))
-                   (#.(char-code #\newline)   (write-string "\\n" stream))
-                   (#.(char-code #\return)    (write-string "\\r" stream))
-                   (#.(char-code #\page)      (write-string "\\f" stream))
-                   (#.(char-code #\tab)       (write-string "\\t" stream))
-                   (t                         (format stream "\\u~4,'0x" code)))
-                 (case code
-                   (#.(char-code #\/)) (when (eql prev #\<) (write-char #\\ stream)) (write-char ch stream)
-                   (#.(char-code #\\)  (write-string "\\\\" stream))
-                   (#.(char-code #\")  (write-string "\\\"" stream))
-                   (t                  (write-char ch stream))))))
-        (loop :for ch :of-type character :across element :do
-           (let ((code (char-code ch)))
-             (declare (fixnum code))
-             (if (or (<= 0 code #x1f)
-                     (<= #x7f code #x9f))
-                 (case code
-                   (#.(char-code #\backspace) (write-string "\\b" stream))
-                   (#.(char-code #\newline)   (write-string "\\n" stream))
-                   (#.(char-code #\return)    (write-string "\\r" stream))
-                   (#.(char-code #\page)      (write-string "\\f" stream))
-                   (#.(char-code #\tab)       (write-string "\\t" stream))
-                   (t                         (format stream "\\u~4,'0x" code)))
-                 (case code
-                   (#.(char-code #\\) (write-string "\\\\" stream))
-                   (#.(char-code #\") (write-string "\\\"" stream))
-                   (t                 (write-char ch stream)))))))
+    (loop :for prev := nil :then ch
+       :for ch :of-type character :across element :do
+       (let ((code (char-code ch)))
+         (declare (fixnum code))
+         (if (or (<= 0 code #x1f)
+                 (<= #x7f code #x9f))
+             (case code
+               (#.(char-code #\backspace) (write-string "\\b" stream))
+               (#.(char-code #\newline)   (write-string "\\n" stream))
+               (#.(char-code #\return)    (write-string "\\r" stream))
+               (#.(char-code #\page)      (write-string "\\f" stream))
+               (#.(char-code #\tab)       (write-string "\\t" stream))
+               (t                         (format stream "\\u~4,'0x" code)))
+             (case code
+               (#.(char-code #\/)  (when (and (eql prev #\<) *script-tag-hack*)
+                                     (write-char #\\ stream))
+                                   (write-char ch stream))
+               (#.(char-code #\\)  (write-string "\\\\" stream))
+               (#.(char-code #\")  (write-string "\\\"" stream))
+               (t                  (write-char ch stream))))))
     (write-char #\" stream)))
 
 (defmethod write-json-element ((element integer) stream)


### PR DESCRIPTION
Enclosed is my code to support JSON UTF-16 surrogate pairs.

Please review and suggest any appropriate improvements.

Credit goes to Jason Miller & Hans Hübner of yason, where I got the elegant and simple translation logic to convert UTF-16 to code points.

While I have also added writer as well (the original code would still work but may output non-Ascii characters - this is still possible with the *output-literal-unicode* option).

I am sure many JSON libraries (notably cl-json https://github.com/hankhero/cl-json/issues/11) continue to suffer from this bug/missing feature, though this feature seems to be used mainly for representing emojis today!

PS: My tests are current embedded as comments within the source file, one day, I assume they can move into properly structured unit tests. It might be a good idea to share certain test samples across all JSON libraries too?

