### PR TITLE
Fix hash table lookups for string keys.

### DIFF
--- a/st-json.lisp
+++ b/st-json.lisp
@@ -254,7 +254,7 @@ Raises a json-type-error when the type is wrong."
            (make-jso :alist (nreverse accum))
            (nreverse accum))))
      (:hashtable
-      (let ((accum (make-hash-table)))
+      (let ((accum (make-hash-table :test #'equal)))
         (gather-comma-separated
          stream #\} "object literal"
          (lambda ()


### PR DESCRIPTION
Objects decoded as hash tables are not usable when the keys are strings. This fixes the issue.

Before fix:
```
(let* ((js "{\"a\":1}")
                (st-json:*DECODE-OBJECTS-AS* :hashtable))
           (gethash "a" (st-json:read-json-from-string js)))
NIL
NIL
```

After fix:
```
(let* ((js "{\"a\":1}")
                (st-json:*DECODE-OBJECTS-AS* :hashtable))
           (gethash "a" (st-json:read-json-from-string js)))
1
T
```