### PR TITLE
Fix emitted format for float values.

### DIFF
--- a/st-json.lisp
+++ b/st-json.lisp
@@ -387,7 +387,7 @@ Raises a json-type-error when the type is wrong."
   (write element :stream stream))
 
 (defmethod write-json-element ((element real) stream)
-  (format stream "~,,,,,,'eE" element))
+  (format stream "~,,,0,,,'eE" element))
 
 (defmethod write-json-element ((element hash-table) stream)
   (declare #.*optimize*)


### PR DESCRIPTION
The original `(format stream "~,,,,,,'eE" element)` doesn't always emit a format that's valid JSON for a value. Example: `{"foo":1.e-1}`