### PR TITLE
Add some convenience and utility functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.fas
+*.fasl
+*.lx64fsl

--- a/index.html
+++ b/index.html
@@ -245,5 +245,12 @@
     line, or any other value to print using the default structure display.
     Default is <code>:one-line</code>.</p>
 
+  <p class="def" id="pretty-print-indent-size">
+    <span>variable</span> *pretty-print-indent-size*
+  </p>
+
+  <p class="desc">The number of spaces to use when pretty printing JSON.
+  Default is 4.</p>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -127,16 +127,55 @@
   <p class="desc"><code>maphash</code> equivalent for JavaScript
   objects.</p>
 
+  <p class="def" id="collect">
+    <span>function</span> collect (function jso)
+  </p>
+
+  <p class="desc"><code>mapcar</code> equivalent for JavaScript
+    objects.  Like <code>mapjso</code>, but returns the results in a list.
+    <br/>&#8594; list
+  </p>
+
+  <p class="def" id="jso-keys">
+    <span>function</span> jso-keys (jso)
+    <br/>&#8594; list
+  </p>
+
+  <p class="desc">Returns a list containing the keys of jso.</p>
+
+  <p class="def" id="jso-values">
+    <span>method</span> jso-values (jso)
+    <br/>&#8594; list
+  </p>
+
+  <p class="desc">Returns a list containing the values of jso.</p>
+
+  <p class="def" id="jso-to-alist">
+    <span>method</span> jso-to-alist (jso)
+    <br/>&#8594; alist
+  </p>
+
+  <p class="desc">Recursively builds an alist representation of jso.</p>
+
+  <p class="def" id="jso-from-alist">
+    <span>method</span> jso-from-alist (jso)
+    <br/>&#8594; jso
+  </p>
+
+  <p class="desc">Construct a jso directly from an alist.
+    This doesn't copy the alist so it shares structure with it.</p>
+
+  
   <p class="def" id="read-json">
     <span>method</span> read-json (source &amp;optional junk-allowed-p)
     <br/>&#8594; value
   </p>
 
-  <p class="desc">Reads a JSON value from an input stream or string.
-  When <code>junk-allowed-p</code> is <code>nil</code>, an error will
-  be raised if any non-whitespace characters are found after the
-  value. This error, and any other parsing errors, will have the type
-  <code>json-parse-error</code>.</p>
+  <p class="desc">Reads a JSON value from an input stream, string,
+    or file.  When <code>junk-allowed-p</code> is <code>nil</code>, an
+    error will be raised if any non-whitespace characters are found
+    after the value. This error, and any other parsing errors, will have
+    the type <code>json-parse-error</code>.</p>
 
   <p class="def" id="read-json-as-type">
     <span>function</span> read-json-as-type (source type)
@@ -173,6 +212,13 @@
   <p class="desc">Generic function used to serialise values as JSON.
   You can specialise it for your own types, if needed.</p>
 
+  <p class="def" id="print-json-element">
+    <span>method</span> print-json-element (element stream)
+  </p>
+
+  <p class="desc">Generic function used to pretty print values as JSON.
+  You can specialise it for your own types, if needed.</p>
+
   <p class="def" id="script-tag-hack">
     <span>variable</span> *script-tag-hack*
   </p>
@@ -183,11 +229,21 @@
   any slash following a '<code>&lt;</code>' character. Default value
   is <code>nil</code>.</p>
 
-  <p class="def" id="script-tag-hack">
+  <p class="def" id="allow-comments">
     <span>variable</span> *allow-comments*
   </p>
 
   <p class="desc">Bind this to <code>t</code> to ignore C++ style
-  end of line comments. Default value is <code>nil</code>.</p>
+    end of line comments. Default value is <code>nil</code>.</p>
+
+  <p class="def" id="print-object-style">
+    <span>variable</span> *print-object-style*
+  </p>
+
+  <p class="desc">Bind this to <code>:pretty</code> to make <code>print-object</code>
+    pretty print <code>jso</code>.   <code>:one-line</code> to print as JSON on a single
+    line, or any other value to print using the default structure display.
+    Default is <code>:one-line</code>.</p>
+
 </body>
 </html>

--- a/st-json.lisp
+++ b/st-json.lisp
@@ -132,7 +132,11 @@ gethash."
 (defgeneric read-json (in &optional junk-allowed-p)
   (:documentation "Read a JSON-encoded value from a stream or a string."))
 
-(defmethod read-json ((in stream) &optional (junk-allowed-p t))
+(defmethod read-json ((in pathname) &optional (junk-allowed-p nil))
+  (with-open-file (stream in :direction :input)
+    (read-json stream junk-allowed-p)))
+
+(defmethod read-json ((in stream) &optional (junk-allowed-p nil))
   (let ((value (read-json-element in)))
     (skip-whitespace in)
     (unless (or junk-allowed-p (at-eof in))

--- a/st-json.lisp
+++ b/st-json.lisp
@@ -69,7 +69,7 @@ gethash."
   "Like mapjso, but returning the results.
    Returns a list with the results of calling func on each key/value pair in a JS object."
   (loop :for (key . val) :in (jso-alist map)
-        :do (collect func key val)))
+        :collect (funcall func key val)))
 
 (defmacro getjso* (keys jso)
   "Takes a key of the form \"a.b.c\", generates a series of getjso calls that

--- a/st-json.lisp
+++ b/st-json.lisp
@@ -5,6 +5,8 @@
            #:as-json-bool #:from-json-bool
            #:json-bool #:json-null
            #:jso #:getjso #:getjso* #:mapjso
+           #:jso-keys #:jso-values
+           #:jso-from-alist
            #:json-error #:json-type-error #:json-parse-error
            #:json-eof-error
            #:*decode-objects-as*
@@ -63,6 +65,17 @@ gethash."
         `(getjso ,(subseq keys (1+ last))
                  (getjso* ,(subseq keys 0 last) ,jso))
         `(getjso ,keys ,jso))))
+
+(defun jso-keys (map)
+  (loop :for (key . val) :in (jso-alist map)
+     :collecting key))
+
+(defun jso-values (map)
+  (loop :for (key . val) :in (jso-alist map)
+        :collecting val))
+
+(defun jso-from-alist (vals)
+  (make-jso :alist vals))
 
 ;; Reader
 

--- a/st-json.lisp
+++ b/st-json.lisp
@@ -10,6 +10,8 @@
            #:json-error #:json-type-error #:json-parse-error
            #:json-eof-error
            #:*decode-objects-as*
+           #:print-json-element
+           #:*print-object-style*
            #:*allow-comments*
            #:*script-tag-hack*
            #:*output-literal-unicode*))
@@ -18,7 +20,7 @@
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defparameter *optimize*
-    '(optimize (speed 3) (safety 0) (space 1) (debug 1) (compilation-speed 0))))
+    '(optimize (speed 2) (safety 1) (space 1) (debug 1) (compilation-speed 0))))
 
 ;; Boolean types. It is hard to see what is meant by NIL when encoding
 ;; a lisp value -- false or [] -- so :false and :true are used instead
@@ -326,6 +328,12 @@ Raises a json-type-error when the type is wrong."
   they can already read UTF-8, or else, they'll need to implement
   complex unicode (eg UTF-16 surrogate pairs) escape parsers.")
 
+(defparameter *print-object-style* :one-line
+  "Set this to control the print style of print-object.
+  :pretty - pretty prints using print-json-element
+  :one-line - writes to a single line using write-json-element
+  any other value uses the built-in structure style.")
+
 (defun write-json-to-string (element)
   "Write a value's JSON representation to a string."
   (with-output-to-string (out)
@@ -430,3 +438,138 @@ Raises a json-type-error when the type is wrong."
          (write-char #\, stream))
      (write-json-element part stream)))
   (write-char #\] stream))
+
+
+(defgeneric print-json-element (element stream &optional indent)
+  (:method (element stream &optional (indent 0))
+    (declare (ignore stream indent))
+    (raise 'json-write-error "Can not pretty-print object of type ~A as JSON." (type-of element)))
+  (:documentation "Method used for pretty printing values of a specific type.
+  You can specialise this for your own types."))
+
+(defparameter *indent-size* 4)
+
+(declaim (inline print-indent))
+(defun print-indent (indentation stream)
+    (write-string (make-string (* (max 0 indentation) *indent-size*) :initial-element #\Space) stream))
+
+(defmethod print-json-element ((element symbol) stream &optional (indent 0))
+  (declare #.*optimize*)
+  (declare (ignorable indent))
+
+  (ecase element
+    ((nil) (write-string "[]" stream))
+    ((t :true) (write-string "true" stream))
+    (:false (write-string "false" stream))
+    ((:null :undefined) (write-string "null" stream))))
+
+(defmethod print-json-element ((element string) stream &optional (indent 0))
+  (declare #.*optimize* (stream stream))
+  (declare (ignorable indent))
+  (let ((element (coerce element 'simple-string)))
+    (write-char #\" stream)
+    (loop :for prev := nil :then ch
+       :for ch :of-type character :across element :do
+       (let ((code (char-code ch)))
+         (declare (fixnum code))
+         (if (or (<= 0 code #x1f)
+                 (<= #x7f code #x9f))
+             (case code
+               (#.(char-code #\backspace) (write-string "\\b" stream))
+               (#.(char-code #\newline)   (write-string "\\n" stream))
+               (#.(char-code #\return)    (write-string "\\r" stream))
+               (#.(char-code #\page)      (write-string "\\f" stream))
+               (#.(char-code #\tab)       (write-string "\\t" stream))
+               (t                         (format stream "\\u~4,'0x" code)))
+             (case code
+               (#.(char-code #\/)  (when (and (eql prev #\<) *script-tag-hack*)
+                                     (write-char #\\ stream))
+                                   (write-char ch stream))
+               (#.(char-code #\\)  (write-string "\\\\" stream))
+               (#.(char-code #\")  (write-string "\\\"" stream))
+               (t                  (cond ((< #x1F code #x7F)
+                                          (write-char ch stream))
+                                         ((and (< #x9F code #x10000)
+                                               (not *output-literal-unicode*))
+                                          (format stream "\\u~4,'0x" code))
+                                         ((and (< #x10000 code #x1FFFF)
+                                               (not *output-literal-unicode*))
+                                          (let ((c (- code #x10000)))
+                                            (format stream "\\u~4,'0x\\u~4,'0x"
+                                                    (logior #xD800 (ash c -10))
+                                                    (logior #xDC00 (logand c #x3FF)))))
+                                         (t
+                                          (write-char ch stream))))))))
+    (write-char #\" stream)))
+
+#+nil
+(let ((st-json:*script-tag-hack* t))
+  (st-json:write-json-to-string "Test 𝄞 ⇓ 	<tag>
+</tag>"))
+;; ==> "\"Test \\uD834\\uDD1E \\u21D3 \\t<tag>\\n<\\/tag>\""
+
+(defmethod print-json-element ((element integer) stream &optional (indent 0))
+  (declare (ignorable indent))
+  (write element :stream stream))
+
+(defmethod print-json-element ((element real) stream &optional (indent 0))
+  (declare (ignorable indent))
+  (format stream "~,,,0,,,'eE" element))
+
+(defmethod print-json-element ((element hash-table) stream &optional (indent 0))
+  (declare #.*optimize*)
+  (declare (type fixnum indent))
+  (print-indent indent stream)
+  (print-json-element
+   (make-jso :alist (loop
+                      :for key :being :the :hash-keys :of element
+                        :using (hash-value val)
+                      :collect (cons key val)))
+   stream
+   (1+ indent)))
+
+(defmethod print-json-element ((element jso) stream &optional (indent 0))
+  (declare #.*optimize*)
+  (declare (type (unsigned-byte 32) indent)
+           (type stream stream))
+  (write-char #\{ stream)
+  (write-char #\Newline stream)
+  (print-indent (1+ indent) stream)
+  (loop :for (key . val) :in (jso-alist element)
+        :for first := t :then nil
+        :unless first :do
+          (write-char #\, stream)
+          (write-char #\Newline stream)
+          (print-indent (1+ indent) stream)
+        :do (print-json-element key stream (1+ indent))
+        :do (write-char #\: stream)
+            (write-char #\Space stream)
+        :do (print-json-element val stream (1+ indent)))
+  (write-char #\Newline stream)
+  (print-indent indent stream)
+  (write-char #\} stream))
+
+(defmethod print-json-element ((element list) stream &optional (indent 0))
+  (declare #.*optimize*)
+  (declare (type fixnum indent))
+  (write-char #\[ stream)
+  (let ((first t))
+    (dolist (part element)
+     (if first
+         (setf first nil)
+         (progn
+           (write-char #\, stream)
+           (write-char #\Newline stream)
+           (print-indent indent stream)))
+      (print-json-element part stream (1+ indent))))
+  (print-indent (1- indent) stream)
+  (write-string "]\\n" stream))
+
+(defmethod print-object ((object jso) stream)
+  (case *print-object-style*
+    (:pretty
+     (print-json-element object stream))
+    (:one-line
+     (write-json object stream))
+    (t
+     (call-next-method))))

--- a/st-json.lisp
+++ b/st-json.lisp
@@ -14,6 +14,7 @@
            #:*decode-objects-as*
            #:print-json-element
            #:*print-object-style*
+           #:*pretty-print-indent-size*
            #:*allow-comments*
            #:*script-tag-hack*
            #:*output-literal-unicode*))
@@ -474,7 +475,8 @@ Raises a json-type-error when the type is wrong."
   (:documentation "Method used for pretty printing values of a specific type.
   You can specialise this for your own types."))
 
-(defparameter *indent-size* 4)
+(defparameter *pretty-print-indent-size* 4
+  "The number of spaces to use when indenting pretty printed JSON.")
 
 (declaim (inline print-indent))
 (defun print-indent (indentation stream)

--- a/st-json.lisp
+++ b/st-json.lisp
@@ -57,7 +57,7 @@ gethash."
 (defun mapjso (func map)
   "Iterate over the key/value pairs in a JS object."
   (loop :for (key . val) :in (jso-alist map)
-        :do (funcall func key val)))
+        :collecting (funcall func key val)))
 
 (defmacro getjso* (keys jso)
   (let ((last (position #\. keys :from-end t)))

--- a/st-json.lisp
+++ b/st-json.lisp
@@ -495,41 +495,7 @@ Raises a json-type-error when the type is wrong."
 (defmethod print-json-element ((element string) stream &optional (indent 0))
   (declare #.*optimize* (stream stream))
   (declare (ignorable indent))
-  (let ((element (coerce element 'simple-string)))
-    (write-char #\" stream)
-    (loop :for prev := nil :then ch
-       :for ch :of-type character :across element :do
-       (let ((code (char-code ch)))
-         (declare (fixnum code))
-         (if (or (<= 0 code #x1f)
-                 (<= #x7f code #x9f))
-             (case code
-               (#.(char-code #\backspace) (write-string "\\b" stream))
-               (#.(char-code #\newline)   (write-string "\\n" stream))
-               (#.(char-code #\return)    (write-string "\\r" stream))
-               (#.(char-code #\page)      (write-string "\\f" stream))
-               (#.(char-code #\tab)       (write-string "\\t" stream))
-               (t                         (format stream "\\u~4,'0x" code)))
-             (case code
-               (#.(char-code #\/)  (when (and (eql prev #\<) *script-tag-hack*)
-                                     (write-char #\\ stream))
-                                   (write-char ch stream))
-               (#.(char-code #\\)  (write-string "\\\\" stream))
-               (#.(char-code #\")  (write-string "\\\"" stream))
-               (t                  (cond ((< #x1F code #x7F)
-                                          (write-char ch stream))
-                                         ((and (< #x9F code #x10000)
-                                               (not *output-literal-unicode*))
-                                          (format stream "\\u~4,'0x" code))
-                                         ((and (< #x10000 code #x1FFFF)
-                                               (not *output-literal-unicode*))
-                                          (let ((c (- code #x10000)))
-                                            (format stream "\\u~4,'0x\\u~4,'0x"
-                                                    (logior #xD800 (ash c -10))
-                                                    (logior #xDC00 (logand c #x3FF)))))
-                                         (t
-                                          (write-char ch stream))))))))
-    (write-char #\" stream)))
+  (write-json-element string stream))
 
 #+nil
 (let ((st-json:*script-tag-hack* t))

--- a/st-json.lisp
+++ b/st-json.lisp
@@ -480,7 +480,7 @@ Raises a json-type-error when the type is wrong."
 
 (declaim (inline print-indent))
 (defun print-indent (indentation stream)
-    (write-string (make-string (* (max 0 indentation) *indent-size*) :initial-element #\Space) stream))
+    (write-string (make-string (* (max 0 indentation) *pretty-print-indent-size*) :initial-element #\Space) stream))
 
 (defmethod print-json-element ((element symbol) stream &optional (indent 0))
   (declare #.*optimize*)
@@ -495,7 +495,7 @@ Raises a json-type-error when the type is wrong."
 (defmethod print-json-element ((element string) stream &optional (indent 0))
   (declare #.*optimize* (stream stream))
   (declare (ignorable indent))
-  (write-json-element string stream))
+  (write-json-element element stream))
 
 #+nil
 (let ((st-json:*script-tag-hack* t))

--- a/st-json.lisp
+++ b/st-json.lisp
@@ -5,6 +5,7 @@
            #:as-json-bool #:from-json-bool
            #:json-bool #:json-null
            #:jso #:getjso #:getjso* #:mapjso
+           #:collect
            #:jso-keys #:jso-values
            #:jso-from-alist
            #:jso-to-alist
@@ -57,32 +58,48 @@ gethash."
     (if pair
         (setf (cdr pair) val)
         (prog1 val (push (cons key val) (jso-alist map))))))
+
 (defun mapjso (func map)
   "Iterate over the key/value pairs in a JS object."
   (loop :for (key . val) :in (jso-alist map)
-        :collecting (funcall func key val)))
+        :do (funcall func key val)))
+
+(defun collect (func map)
+  "Like mapjso, but returning the results.
+   Returns a list with the results of calling func on each key/value pair in a JS object."
+  (loop :for (key . val) :in (jso-alist map)
+        :do (collect func key val)))
 
 (defmacro getjso* (keys jso)
+  "Takes a key of the form \"a.b.c\", generates a series of getjso calls that
+   descend into the object and returns 'c'."
   (let ((last (position #\. keys :from-end t)))
     (if last
         `(getjso ,(subseq keys (1+ last))
                  (getjso* ,(subseq keys 0 last) ,jso))
         `(getjso ,keys ,jso))))
 
-(defun jso-keys (map)
-  (loop :for (key . val) :in (jso-alist map)
-     :collecting key))
+(defun jso-keys (obj)
+  "Returns a list of all keys in obj"
+  (loop :for (key . nil) :in (jso-alist obj)
+        :collecting key))
 
 (defun jso-values (map)
-  (loop :for (key . val) :in (jso-alist map)
+  "Returns a list of all values in obj"
+  (loop :for (nil . val) :in (jso-alist obj)
         :collecting val))
 
 (defun jso-from-alist (vals)
+  "Construct a jso directly with an existing alist"
   (make-jso :alist vals))
 
 (defun jso-to-alist (jso-val)
+  "Recursively build an alist from jso-val"
   (typecase jso-val
-    (jso (mapjso (lambda (key val) (cons key (jso-to-alist val))) jso-val))
+    (jso (collect (lambda (key val)
+                    (cons key
+                          (jso-to-alist val)))
+           jso-val))
     (t jso-val)))
 
 ;; Reader

--- a/st-json.lisp
+++ b/st-json.lisp
@@ -7,6 +7,7 @@
            #:jso #:getjso #:getjso* #:mapjso
            #:jso-keys #:jso-values
            #:jso-from-alist
+           #:jso-to-alist
            #:json-error #:json-type-error #:json-parse-error
            #:json-eof-error
            #:*decode-objects-as*
@@ -78,6 +79,11 @@ gethash."
 
 (defun jso-from-alist (vals)
   (make-jso :alist vals))
+
+(defun jso-to-alist (jso-val)
+  (typecase jso-val
+    (jso (mapjso (lambda (key val) (cons key (jso-to-alist val))) jso-val))
+    (t jso-val)))
 
 ;; Reader
 


### PR DESCRIPTION
I've had these in a local branch for a while and would like to upstream them.

The biggest change is pretty-printing.  It can be turned off by setting `*print-object-style*` to nil.  The number of spaces for indentation is controlled by setting `*pretty-print-indent-size*`.  I've found pretty printing to be really helpful working with JSON in the REPL.

The other additions: collect, jso-to-alist, jso-from-alist, jso-keys, and jso-values; are pretty simple, but I found myself using them a lot in different projects, and thought they made more sense in the JSON library.